### PR TITLE
Change Builder implementation to interface

### DIFF
--- a/src/main/kotlin/net/rentalhost/plugins/laravel/hammer/services/IlluminateService.kt
+++ b/src/main/kotlin/net/rentalhost/plugins/laravel/hammer/services/IlluminateService.kt
@@ -10,7 +10,7 @@ object IlluminateService {
             }
 
             object Builder {
-                const val name: String = "\\Illuminate\\Database\\Eloquent\\Builder"
+                const val name: String = "\\Illuminate\\Contracts\\Database\\Eloquent\\Builder"
             }
         }
     }


### PR DESCRIPTION
Scopes require the Contract in my opinion, because of when you call a scope from a relation directly. 

Example: 
```$model->relation()->active();```

This will return an error as the active() is called on the Relation class instead of the Eloquent Builder, which is not extended by it.